### PR TITLE
Bugfix/disallow negative cvrmse

### DIFF
--- a/opendsm/common/clustering/cluster.py
+++ b/opendsm/common/clustering/cluster.py
@@ -64,16 +64,16 @@ def _bisecting_kmeans_clustering(
     clusters features using Bisecting K-Means algorithm
     """
     
-    recluster_count = settings._algorithm.recluster_count
-    n_cluster_lower = settings._algorithm.n_cluster.lower
-    n_cluster_upper = settings._algorithm.n_cluster.upper
-    n_init = settings._algorithm.internal_recluster_count
-    inner_algorithm = settings._algorithm.inner_algorithm
-    bisecting_strategy = settings._algorithm.bisecting_strategy
+    recluster_count = settings.bisecting_kmeans.recluster_count
+    n_cluster_lower = settings.bisecting_kmeans.n_cluster.lower
+    n_cluster_upper = settings.bisecting_kmeans.n_cluster.upper
+    n_init = settings.bisecting_kmeans.internal_recluster_count
+    inner_algorithm = settings.bisecting_kmeans.inner_algorithm
+    bisecting_strategy = settings.bisecting_kmeans.bisecting_strategy
 
-    score_choice = settings._algorithm.scoring.score_metric
-    dist_metric = settings._algorithm.scoring.distance_metric
-    min_cluster_size = settings._algorithm.scoring.min_cluster_size
+    score_choice = settings.bisecting_kmeans.scoring.score_metric
+    dist_metric = settings.bisecting_kmeans.scoring.distance_metric
+    min_cluster_size = settings.bisecting_kmeans.scoring.min_cluster_size
     max_non_outlier_cluster_count = 200
 
     seed = settings._seed
@@ -134,14 +134,14 @@ def _birch_clustering(
     Clusters features using Birch algorithm
     """
 
-    n_cluster_lower = settings._algorithm.n_cluster.lower
-    n_cluster_upper = settings._algorithm.n_cluster.upper
-    threshold = settings._algorithm.threshold
-    branching_factor = settings._algorithm.branching_factor
+    n_cluster_lower = settings.birch.n_cluster.lower
+    n_cluster_upper = settings.birch.n_cluster.upper
+    threshold = settings.birch.threshold
+    branching_factor = settings.birch.branching_factor
 
-    score_choice = settings._algorithm.scoring.score_metric
-    dist_metric = settings._algorithm.scoring.distance_metric
-    min_cluster_size = settings._algorithm.scoring.min_cluster_size
+    score_choice = settings.birch.scoring.score_metric
+    dist_metric = settings.birch.scoring.distance_metric
+    min_cluster_size = settings.birch.scoring.min_cluster_size
     max_non_outlier_cluster_count = 200
 
     results = []
@@ -193,12 +193,12 @@ def _dbscan_clustering(
     clusters features using DBSCAN algorithm
     """
     algo = DBSCAN(
-        eps=settings._algorithm.epsilon, 
-        min_samples=settings._algorithm.min_samples, 
-        metric=settings._algorithm.distance_metric.value,
-        algorithm=settings._algorithm.nearest_neighbors_algorithm,
-        leaf_size=settings._algorithm.leaf_size,
-        p=settings._algorithm.minkowski_p,
+        eps=settings.dbscan.epsilon, 
+        min_samples=settings.dbscan.min_samples, 
+        metric=settings.dbscan.distance_metric.value,
+        algorithm=settings.dbscan.nearest_neighbors_algorithm,
+        leaf_size=settings.dbscan.leaf_size,
+        p=settings.dbscan.minkowski_p,
     )
     labels = algo.fit_predict(data)
 
@@ -212,25 +212,25 @@ def _hdbscan_clustering(
     """
     clusters features using HDBSCAN algorithm
     """
-    min_samples = settings._algorithm.min_samples
-    if settings._algorithm.min_samples == 1:
+    min_samples = settings.hdbscan.min_samples
+    if settings.hdbscan.min_samples == 1:
         min_samples = 2
 
     algo = HDBSCAN(
-        min_samples=settings._algorithm.scoring_sample_count, 
+        min_samples=settings.hdbscan.scoring_sample_count, 
         min_cluster_size=min_samples,
-        allow_single_cluster=settings._algorithm.allow_single_cluster,
-        max_cluster_size=settings._algorithm.max_cluster_size,
-        metric=settings._algorithm.distance_metric,
-        cluster_selection_epsilon=settings._algorithm.cluster_selection_epsilon,
-        alpha=settings._algorithm.robust_single_linkage_scaling,
-        algorithm=settings._algorithm.nearest_neighbors_algorithm,
-        leaf_size=settings._algorithm.leaf_size,
-        cluster_selection_method=settings._algorithm.cluster_selection_method,
+        allow_single_cluster=settings.hdbscan.allow_single_cluster,
+        max_cluster_size=settings.hdbscan.max_cluster_size,
+        metric=settings.hdbscan.distance_metric,
+        cluster_selection_epsilon=settings.hdbscan.cluster_selection_epsilon,
+        alpha=settings.hdbscan.robust_single_linkage_scaling,
+        algorithm=settings.hdbscan.nearest_neighbors_algorithm,
+        leaf_size=settings.hdbscan.leaf_size,
+        cluster_selection_method=settings.hdbscan.cluster_selection_method,
     )
     labels = algo.fit_predict(data)
 
-    if settings._algorithm.min_samples == 1:
+    if settings.hdbscan.min_samples == 1:
         # get count of -1 labels
         outlier_count = np.sum(labels == -1)
 
@@ -253,12 +253,12 @@ def _spectral_clustering(
     """
     clusters features using Spectral Clustering algorithm
     """
-    n_cluster_lower = settings._algorithm.n_cluster.lower
-    n_cluster_upper = settings._algorithm.n_cluster.upper
+    n_cluster_lower = settings.spectral.n_cluster.lower
+    n_cluster_upper = settings.spectral.n_cluster.upper
     
-    score_choice = settings._algorithm.scoring.score_metric
-    dist_metric = settings._algorithm.scoring.distance_metric
-    min_cluster_size = settings._algorithm.scoring.min_cluster_size
+    score_choice = settings.spectral.scoring.score_metric
+    dist_metric = settings.spectral.scoring.distance_metric
+    min_cluster_size = settings.spectral.scoring.min_cluster_size
     max_non_outlier_cluster_count = 200
 
     # transform data as spectral clustering doesn't like negative values
@@ -268,19 +268,19 @@ def _spectral_clustering(
     results = []
     for n_clusters in range(n_cluster_lower, n_cluster_upper + 1):
         if n_clusters == n_cluster_lower:
-            affinity = settings._algorithm.affinity
+            affinity = settings.spectral.affinity
         else:
             affinity = "precomputed"
 
         algo = SpectralClustering(
             n_clusters=n_clusters,
-            eigen_solver=settings._algorithm.eigen_solver,
-            n_components=settings._algorithm.n_components,
+            eigen_solver=settings.spectral.eigen_solver,
+            n_components=settings.spectral.n_components,
             affinity=affinity,
-            n_neighbors=settings._algorithm.nearest_neighbors,
-            gamma=settings._algorithm.gamma,
-            eigen_tol=settings._algorithm.eigen_tol,
-            assign_labels=settings._algorithm.assign_labels,
+            n_neighbors=settings.spectral.nearest_neighbors,
+            gamma=settings.spectral.gamma,
+            eigen_tol=settings.spectral.eigen_tol,
+            assign_labels=settings.spectral.assign_labels,
         )
 
         # hide UserWarning from sklearn
@@ -415,8 +415,9 @@ def cluster_features(
 ):
     
     # bypass clustering if cluster count is >= data
-    if settings.clustering_algorithm not in ["dbscan", "hdbscan"]:
-        if settings._algorithm.n_cluster.lower >= len(data):
+    if settings.algorithm_selection not in ["dbscan", "hdbscan"]:
+        algo = getattr(settings, f"{settings.algorithm_selection.value}")
+        if algo.n_cluster.lower >= len(data):
             return np.arange(len(data))
 
     # standardize the data
@@ -428,18 +429,18 @@ def cluster_features(
         data = _transform_data(data, settings)
 
     # cluster the pca features
-    if settings.clustering_algorithm == "bisecting_kmeans":
+    if settings.algorithm_selection == "bisecting_kmeans":
         cluster_fcn = _bisecting_kmeans_clustering
-    elif settings.clustering_algorithm == "birch":
+    elif settings.algorithm_selection == "birch":
         cluster_fcn = _birch_clustering
-    elif settings.clustering_algorithm == "dbscan":
+    elif settings.algorithm_selection == "dbscan":
         cluster_fcn = _dbscan_clustering
-    elif settings.clustering_algorithm == "hdbscan":
+    elif settings.algorithm_selection == "hdbscan":
         cluster_fcn = _hdbscan_clustering
-    elif settings.clustering_algorithm == "spectral":
+    elif settings.algorithm_selection == "spectral":
         cluster_fcn = _spectral_clustering
     else:
-        raise ValueError(f"Unknown clustering algorithm: {settings.clustering_algorithm}")
+        raise ValueError(f"Unknown clustering algorithm: {settings.algorithm_selection}")
     
     cluster_labels = cluster_fcn(data, settings)
 

--- a/opendsm/common/clustering/cluster.py
+++ b/opendsm/common/clustering/cluster.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+
+   Copyright 2014-2025 OpenDSM contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from pydantic import BaseModel, ConfigDict
+
+import pywt
+
+from sklearn.preprocessing import StandardScaler, RobustScaler
+from sklearn.decomposition import PCA, KernelPCA
+from sklearn.cluster import DBSCAN, HDBSCAN, Birch, SpectralClustering
+
+
+
+from opendsm.common.clustering import (
+    bisect_k_means as _bisect_k_means,
+    scoring as _scoring,
+    settings as _settings,
+)
+
+
+
+class _LabelResult(BaseModel):
+    """
+    contains metrics about a cluster label returned from sklearn
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    labels: np.ndarray
+    score: float
+    score_unable_to_be_calculated: bool
+    n_clusters: int
+
+
+def _bisecting_kmeans_clustering(
+    data: np.ndarray,
+    settings: _settings.ClusteringSettings
+):
+    """
+    clusters features using Bisecting K-Means algorithm
+    """
+    
+    recluster_count = settings._algorithm.recluster_count
+    n_cluster_lower = settings._algorithm.n_cluster.lower
+    n_cluster_upper = settings._algorithm.n_cluster.upper
+    n_init = settings._algorithm.internal_recluster_count
+    inner_algorithm = settings._algorithm.inner_algorithm
+    bisecting_strategy = settings._algorithm.bisecting_strategy
+
+    score_choice = settings._algorithm.scoring.score_metric
+    dist_metric = settings._algorithm.scoring.distance_metric
+    min_cluster_size = settings._algorithm.scoring.min_cluster_size
+    max_non_outlier_cluster_count = 200
+
+    seed = settings._seed
+
+    results = []
+    for i in range(recluster_count):
+        algo = _bisect_k_means.BisectingKMeans(
+            n_clusters=n_cluster_upper,
+            init="k-means++",  # does not benefit from k-means++ like other k-means
+            n_init=n_init,
+            random_state=seed + i,
+            algorithm=inner_algorithm,
+            bisecting_strategy=bisecting_strategy,
+        )
+        algo.fit(data)
+        labels_dict = algo.labels_full
+
+        # if specifying clusters, only score the specified clusters
+        if n_cluster_lower == n_cluster_upper:
+            labels_dict = {n_cluster_lower: labels_dict[n_cluster_lower]}
+
+        for n_cluster, labels in labels_dict.items():
+            score, score_unable_to_be_calculated = _scoring.score_clusters(
+                data,
+                labels,
+                n_cluster_lower,
+                score_choice,
+                dist_metric,
+                min_cluster_size,
+                max_non_outlier_cluster_count,
+            )
+
+            label_res = _LabelResult(
+                labels=labels,
+                score=score,
+                score_unable_to_be_calculated=score_unable_to_be_calculated,
+                n_clusters=n_cluster,
+            )
+            results.append(label_res)
+
+    # get the results index with the smallest score
+    HoF = None
+    for result in results:
+        if result.score_unable_to_be_calculated:
+            continue
+
+        if HoF is None or result.score < HoF.score:
+            HoF = result
+
+    return HoF.labels
+
+
+def _birch_clustering(
+    data: np.ndarray,
+    settings: _settings.ClusteringSettings
+):
+    """
+    Clusters features using Birch algorithm
+    """
+
+    n_cluster_lower = settings._algorithm.n_cluster.lower
+    n_cluster_upper = settings._algorithm.n_cluster.upper
+    threshold = settings._algorithm.threshold
+    branching_factor = settings._algorithm.branching_factor
+
+    score_choice = settings._algorithm.scoring.score_metric
+    dist_metric = settings._algorithm.scoring.distance_metric
+    min_cluster_size = settings._algorithm.scoring.min_cluster_size
+    max_non_outlier_cluster_count = 200
+
+    results = []
+    for n_clusters in range(n_cluster_lower, n_cluster_upper + 1):
+        algo = Birch(
+            n_clusters=n_clusters,
+            threshold=threshold,
+            branching_factor=branching_factor,
+        )
+        labels = algo.fit_predict(data)
+        
+        # Calculate score for the clusters
+        score, score_unable_to_be_calculated = _scoring.score_clusters(
+                data,
+                labels,
+                n_cluster_lower,
+                score_choice,
+                dist_metric,
+                min_cluster_size,
+                max_non_outlier_cluster_count,
+            )
+        
+        label_res = _LabelResult(
+                labels=labels,
+                score=score,
+                score_unable_to_be_calculated=score_unable_to_be_calculated,
+                n_clusters=n_clusters,
+            )
+        
+        results.append(label_res)
+
+    # get the results index with the smallest score
+    HoF = None
+    for result in results:
+        if result.score_unable_to_be_calculated:
+            continue
+
+        if HoF is None or result.score < HoF.score:
+            HoF = result
+
+    return HoF.labels
+
+
+def _dbscan_clustering(
+    data: np.ndarray,
+    settings: _settings.ClusteringSettings
+):
+    """
+    clusters features using DBSCAN algorithm
+    """
+    algo = DBSCAN(
+        eps=settings._algorithm.epsilon, 
+        min_samples=settings._algorithm.min_samples, 
+        metric=settings._algorithm.distance_metric,
+        algorithm=settings._algorithm.nearest_neighbors_algorithm,
+        leaf_size=settings._algorithm.leaf_size,
+        p=settings._algorithm.minkowski_p,
+    )
+    labels = algo.fit_predict(data)
+
+    return labels
+
+
+def _hdbscan_clustering(
+    data: np.ndarray,
+    settings: _settings.ClusteringSettings
+):
+    """
+    clusters features using HDBSCAN algorithm
+    """
+    algo = HDBSCAN(
+        min_samples=settings._algorithm.scoring_sample_count, 
+        min_cluster_size=settings._algorithm.min_samples,
+        allow_single_cluster=settings._algorithm.allow_single_cluster,
+        max_cluster_size=settings._algorithm.max_cluster_size,
+        metric=settings._algorithm.distance_metric,
+        cluster_selection_epsilon=settings._algorithm.cluster_selection_epsilon,
+        alpha=settings._algorithm.robust_single_linkage_scaling,
+        algorithm=settings._algorithm.nearest_neighbors_algorithm,
+        leaf_size=settings._algorithm.leaf_size,
+        cluster_selection_method=settings._algorithm.cluster_selection_method,
+    )
+    labels = algo.fit_predict(data)
+
+    return labels
+
+
+def _spectral_clustering(
+    data: np.ndarray,
+    settings: _settings.ClusteringSettings
+):
+    """
+    clusters features using Spectral Clustering algorithm
+    """
+    n_cluster_lower = settings._algorithm.n_cluster.lower
+    n_cluster_upper = settings._algorithm.n_cluster.upper
+    
+    score_choice = settings._algorithm.scoring.score_metric
+    dist_metric = settings._algorithm.scoring.distance_metric
+    min_cluster_size = settings._algorithm.scoring.min_cluster_size
+    max_non_outlier_cluster_count = 200
+
+    results = []
+    for n_clusters in range(n_cluster_lower, n_cluster_upper + 1):
+        algo = SpectralClustering(
+            n_clusters=n_clusters,
+            eigen_solver=settings._algorithm.eigen_solver,
+            n_components=settings._algorithm.n_components,
+            affinity=settings._algorithm.affinity,
+            n_neighbors=settings._algorithm.nearest_neighbors,
+            gamma=settings._algorithm.gamma,
+            eigen_tol=settings._algorithm.eigen_tol,
+            assign_labels=settings._algorithm.assign_labels,
+        )
+        labels = algo.fit_predict(data)
+
+        # Calculate a score for the clustering
+        score, score_unable_to_be_calculated = _scoring.score_clusters(
+                data,
+                labels,
+                n_cluster_lower,
+                score_choice,
+                dist_metric,
+                min_cluster_size,
+                max_non_outlier_cluster_count,
+            )
+        
+        label_res = _LabelResult(
+                labels=labels,
+                score=score,
+                score_unable_to_be_calculated=score_unable_to_be_calculated,
+                n_clusters=n_clusters,
+            )
+        
+        results.append(label_res)
+
+    # get the results index with the smallest score
+    HoF = None
+    for result in results:
+        if result.score_unable_to_be_calculated:
+            continue
+
+        if HoF is None or result.score < HoF.score:
+            HoF = result
+
+    return HoF.labels
+
+
+def _transform_data(
+    data: pd.DataFrame,
+    settings: _settings.ClusteringSettings
+):
+    """
+    Transforms the data using the wavelet transform settings
+    """
+    settings = settings.transform_settings
+
+    def _dwt_coeffs(data, wavelet="db1", wavelet_mode="periodization", n_levels=4):
+        all_features = []
+        # iterate through rows of numpy array
+        for row in range(len(data)):
+            decomp_coeffs = pywt.wavedec(
+                data[row], wavelet=wavelet, mode=wavelet_mode, level=n_levels
+            )
+            # remove last level
+            # if n_levels > 4:
+            # decomp_coeffs = decomp_coeffs[:-1]
+
+            decomp_coeffs = np.hstack(decomp_coeffs)
+
+            all_features.append(decomp_coeffs)
+
+        return np.vstack(all_features)
+
+    def _pca_coeffs(features, min_var_ratio_explained=0.95, n_components=None):
+        if min_var_ratio_explained is not None:
+            n_components = min_var_ratio_explained
+
+        # kernel pca is not fully developed
+        use_kernel_pca = False
+        if use_kernel_pca:
+            pca = KernelPCA(n_components=None, kernel="rbf")
+            pca_features = pca.fit_transform(features)
+
+            if min_var_ratio_explained is not None:
+                explained_variance_ratio = pca.eigenvalues_ / np.sum(pca.eigenvalues_)
+
+                # get the cumulative explained variance ratio
+                cumulative_explained_variance = np.cumsum(explained_variance_ratio)
+
+                # find number of components that explain pct% of the variance
+                n_components = np.argmax(cumulative_explained_variance > n_components).astype(int)
+
+            if not isinstance(n_components, int):
+                raise ValueError("n_components must be an integer for kernel PCA")
+
+            # pca = PCA(n_components=n_components)
+            pca = KernelPCA(n_components=n_components, kernel="rbf")
+            pca_features = pca.fit_transform(features)
+
+        else:
+            pca = PCA(n_components=n_components)
+            pca_features = pca.fit_transform(features)
+
+        return pca_features
+
+    # calculate wavelet coefficients
+    with warnings.catch_warnings():
+        # TODO wavelet level 5 was chosen during hyperparam optimization, but
+        # worth investigating this further
+        warnings.filterwarnings("ignore", module="pywt._multilevel")
+        features = _dwt_coeffs(
+            data, 
+            settings.wavelet_name, 
+            settings.wavelet_mode, 
+            settings.wavelet_n_levels
+        )
+
+    pca_features = _pca_coeffs(
+        features, 
+        settings.pca_min_variance_ratio_explained,
+        settings.pca_n_components,
+    )
+
+    # normalize pca features
+    if settings._standardize:
+        pca_features = (pca_features - pca_features.mean()) / pca_features.std()
+
+    if settings.pca_include_median:
+        pca_features = np.hstack([pca_features, np.median(data, axis=1)[:, None]])
+
+    return pca_features
+
+
+
+def cluster_features(
+    data: np.ndarray,
+    settings: _settings.ClusteringSettings,
+):
+    
+    # bypass clustering if cluster count is >= data
+    if settings.clustering_algorithm not in ["dbscan", "hdbscan"]:
+        if settings._algorithm.n_cluster.lower >= len(data):
+            return np.arange(len(data))
+
+    # standardize the data
+    if settings.standardize:
+        data = (data - data.mean()) / data.std()
+
+    # transform the data
+    if settings.transform_settings is not None:
+        data = _transform_data(data, settings)
+
+    # cluster the pca features
+    if settings.clustering_algorithm == "bisecting_kmeans":
+        cluster_fcn = _bisecting_kmeans_clustering
+    elif settings.clustering_algorithm == "birch":
+        cluster_fcn = _birch_clustering
+    elif settings.clustering_algorithm == "dbscan":
+        cluster_fcn = _dbscan_clustering
+    elif settings.clustering_algorithm == "hdbscan":
+        cluster_fcn = _hdbscan_clustering
+    elif settings.clustering_algorithm == "spectral":
+        cluster_fcn = _spectral_clustering
+    else:
+        raise ValueError(f"Unknown clustering algorithm: {settings.clustering_algorithm}")
+    
+    cluster_labels = cluster_fcn(data, settings)
+
+    return cluster_labels

--- a/opendsm/common/clustering/settings.py
+++ b/opendsm/common/clustering/settings.py
@@ -361,7 +361,7 @@ class SpectralSettings(BaseSettings):
 
     """number of nearest neighbors to use for nearest neighbors kernel"""
     nearest_neighbors: int = pydantic.Field(
-        default=10,
+        default=5,
         ge=1,
     )
 
@@ -372,7 +372,7 @@ class SpectralSettings(BaseSettings):
     )
 
     """stopping criterion for eigen decomposition"""
-    eigen_tol: Literal["auto"] = pydantic.Field(
+    eigen_tol: Union[float, Literal["auto"]] = pydantic.Field(
         default="auto",
     )
 
@@ -388,6 +388,16 @@ class SpectralSettings(BaseSettings):
     scoring: ScoreSettings = pydantic.Field(
         default_factory=ScoreSettings
     )
+
+    @pydantic.model_validator(mode="after")
+    def _check_eigen_tol(self):
+        if self.eigen_tol != "auto":
+            if self.eigen_tol < 0:
+                raise ValueError(
+                    "'eigen_tol' must be >= 0"
+                )
+
+        return self
 
 
 class ClusteringSettings(BaseSettings):

--- a/opendsm/common/clustering/settings.py
+++ b/opendsm/common/clustering/settings.py
@@ -400,6 +400,14 @@ class SpectralSettings(BaseSettings):
         return self
 
 
+class ClusterAlgorithms(str, Enum):
+    BISECTING_KMEANS = "bisecting_kmeans"
+    BIRCH = "birch"
+    DBSCAN = "dbscan"
+    HDBSCAN = "hdbscan"
+    SPECTRAL = "spectral"
+
+
 class ClusteringSettings(BaseSettings):
     """standardize data boolean"""
     standardize: bool = pydantic.Field(
@@ -412,13 +420,33 @@ class ClusteringSettings(BaseSettings):
     )
 
     """clustering choice"""
-    clustering_algorithm: str = pydantic.Field(
-        default="spectral",
+    algorithm_selection: ClusterAlgorithms = pydantic.Field(
+        default=ClusterAlgorithms.SPECTRAL,
     )
-    
-    ## dict of options for selected clusteringalgorithm
-    clustering_algorithm_settings: Optional[dict] = pydantic.Field(
-        default=None,
+
+    """BisectingKMeans settings"""
+    bisecting_kmeans: BisectingKMeansSettings = pydantic.Field(
+        default_factory=BisectingKMeansSettings,
+    )
+
+    """Birch settings"""
+    birch: BirchSettings = pydantic.Field(
+        default_factory=BirchSettings,
+    )
+
+    """DBSCAN settings"""
+    dbscan: DBSCANSettings = pydantic.Field(
+        default_factory=DBSCANSettings,
+    )
+
+    """HDBSCAN settings"""
+    hdbscan: HDBSCANSettings = pydantic.Field(
+        default_factory=HDBSCANSettings,
+    )
+
+    """Spectral settings"""
+    spectral: SpectralSettings = pydantic.Field(
+        default_factory=SpectralSettings,
     )
 
     """seed for random state assignment"""
@@ -435,28 +463,6 @@ class ClusteringSettings(BaseSettings):
             self._seed = self.seed
 
         self._seed = self._seed
-
-        return self
-    
-    @pydantic.model_validator(mode="after")
-    def _assign_algorithm(self):
-        algo_dict = {
-            "bisecting_kmeans": BisectingKMeansSettings,
-            "birch": BirchSettings,
-            "dbscan": DBSCANSettings,
-            "hdbscan": HDBSCANSettings,
-            "spectral": SpectralSettings,
-        }
-
-        if self.clustering_algorithm not in algo_dict:
-            raise ValueError(
-                f"'name' must be one of the following: \n{list(algo_dict.keys())}"
-            )
-
-        if self.clustering_algorithm_settings is None:
-            self._algorithm = algo_dict[self.clustering_algorithm]()
-        else:
-            self._algorithm = algo_dict[self.clustering_algorithm](**self.clustering_algorithm_settings)
 
         return self
 

--- a/opendsm/common/hourly_interpolation.py
+++ b/opendsm/common/hourly_interpolation.py
@@ -212,7 +212,10 @@ def _interpolate_col(x, lags):
         nan_idx = x.index.get_indexer(nan_series_idx)
 
         # for each row, if the value is missing, calculate the mean of the lags and leads
-        x.loc[nan_series_idx] = np.nanmean(autocorr_helpers[nan_idx, :], axis=1)
+        # ignore FutureWarning from pandas for now
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=FutureWarning)
+            x.loc[nan_series_idx] = np.nanmean(autocorr_helpers[nan_idx, :], axis=1)
 
         if x.isna().sum() == 0:
             break

--- a/opendsm/eemeter/models/daily/utilities/settings.py
+++ b/opendsm/eemeter/models/daily/utilities/settings.py
@@ -381,6 +381,13 @@ class DailySettings(BaseSettings):
         description="Threshold for the CVRMSE to disqualify a model",
     )
 
+    pnrmse_threshold: float = CustomField(
+        default=1.6,
+        ge=0,
+        developer=True,
+        description="Threshold for the PNRMSE to disqualify a model",
+    )
+
 
     @pydantic.model_validator(mode="after")
     def _check_developer_mode(self):

--- a/opendsm/eemeter/models/hourly/model.py
+++ b/opendsm/eemeter/models/hourly/model.py
@@ -1030,10 +1030,20 @@ class HourlyModel:
     def _model_fit_is_acceptable(self):
         cvrmse = self.baseline_metrics.cvrmse_adj
         pnrmse = self.baseline_metrics.pnrmse_adj
-        if (cvrmse is not None and cvrmse < self.settings.cvrmse_threshold) or (
-            pnrmse is not None and pnrmse < self.settings.pnrmse_threshold
-        ):
-            return True
+
+        # sufficient is (0 <= cvrmse <= threshold) or (0 <= pnrmse <= threshold)
+
+        if cvrmse is not None:
+            if (0 <= cvrmse) and (cvrmse <= self.settings.cvrmse_threshold):
+                return True
+            
+        if pnrmse is not None:
+            # less than 0 is not possible, but just in case
+            if (0 <= pnrmse) and (pnrmse <= self.settings.pnrmse_threshold):
+                return True
+
+        return False
+
 
     def to_dict(self) -> dict:
         """Returns a dictionary of model parameters.

--- a/opendsm/eemeter/models/hourly/model.py
+++ b/opendsm/eemeter/models/hourly/model.py
@@ -280,12 +280,14 @@ class HourlyModel:
 
             rmse_annual = np.sqrt(np.mean(resid ** 2))
 
-            rel_diff = (rmse_annual - rmse_annual_prior) / rmse_annual_prior
-            rmse_annual_prior = rmse_annual
+            if i > 0:
+                rel_diff = (rmse_annual - rmse_annual_prior) / rmse_annual_prior
 
-            # if rmse is not changing much, break
-            if rel_diff < self.settings.elasticnet.adaptive_weight_tol:
-                break
+                # if rmse is not changing much, break
+                if rel_diff < self.settings.elasticnet.adaptive_weight_tol:
+                    break
+
+            rmse_annual_prior = rmse_annual
 
             # for each day, calculate rmse to downweight outlier days
             rmse_daily = np.sqrt(np.mean(resid**2, axis=1))
@@ -567,10 +569,9 @@ class HourlyModel:
                 values="observed",
             )
 
-            settings = self.settings.temporal_cluster
             labels = cluster_features(
                 fit_df_grouped.values,
-                settings.temporal_cluster
+                self.settings.temporal_cluster
             )
 
             df_temporal_clusters = pd.DataFrame(

--- a/opendsm/eemeter/models/hourly/settings.py
+++ b/opendsm/eemeter/models/hourly/settings.py
@@ -39,6 +39,10 @@ class DefaultTrainingFeatures(str, Enum):
     SOLAR = ["temperature", "ghi"]
     NONSOLAR = ["temperature"]
 
+class AggregationMethod(str, Enum):
+    MEAN = "mean"
+    MEDIAN = "median"
+
 
 class TemperatureBinSettings(BaseSettings):
     """how to bin temperature data"""
@@ -265,6 +269,17 @@ class BaseHourlySettings(BaseSettings):
     """settings for temporal clustering"""
     temporal_cluster: ClusteringSettings = pydantic.Field(
         default_factory=ClusteringSettings,
+    )
+
+    """temporal cluster aggregation method"""
+    temporal_cluster_aggregation: AggregationMethod = pydantic.Field(
+        default=AggregationMethod.MEDIAN,
+    )
+
+    """temporal cluster/temperature bin/temperature interaction scalar"""
+    interaction_scalar: float = pydantic.Field(
+        default=0.5,
+        gt=0,
     )
 
     """supplemental time series column names"""

--- a/opendsm/eemeter/models/hourly/settings.py
+++ b/opendsm/eemeter/models/hourly/settings.py
@@ -149,7 +149,7 @@ class ElasticNetSettings(BaseSettings):
     """ElasticNet alpha parameter"""
 
     alpha: float = pydantic.Field(
-        default=0.0425,
+        default=0.01, # TODO: Change this back to 0.0425
         ge=0,
     )
 
@@ -195,18 +195,18 @@ class ElasticNetSettings(BaseSettings):
 
     """Adaptive Daily Weights for ElasticNet"""
     adaptive_weights: bool = pydantic.Field(
-        default=False,
+        default=True,
     )
 
     """Number of iterations to iterate weights"""
     adaptive_weight_max_iter: Optional[int] = pydantic.Field(
-        default=None,   # Previously was using 100 as it exits early where appropriate
+        default=100,   # Previously was using 100 as it exits early where appropriate
         ge=1,
     )
 
     """Relative difference in weights to stop iteration"""
     adaptive_weight_tol: Optional[float] = pydantic.Field(
-        default=None,   # Previously was using 1e-4
+        default=1E-4,   # Previously was using 1e-4
         ge=0,
     )
 

--- a/opendsm/eemeter/models/hourly/settings.py
+++ b/opendsm/eemeter/models/hourly/settings.py
@@ -196,7 +196,7 @@ class TemporalClusteringSettings(BaseSettings):
 
     """lower bound for number of clusters"""
     n_cluster_lower: int = pydantic.Field(
-        default=2,
+        default=12,
         ge=2,
     )
 

--- a/opendsm/eemeter/models/hourly/settings.py
+++ b/opendsm/eemeter/models/hourly/settings.py
@@ -200,7 +200,7 @@ class ElasticNetSettings(BaseSettings):
 
     """Number of iterations to iterate weights"""
     adaptive_weight_max_iter: Optional[int] = pydantic.Field(
-        default=100,   # Previously was using 100 as it exits early where appropriate
+        default=10,   # Previously was using 100 as it exits early where appropriate
         ge=1,
     )
 

--- a/tests/test_hourly_model.py
+++ b/tests/test_hourly_model.py
@@ -291,13 +291,13 @@ def test_hourly_fit_daily_threshold(baseline):
     b1 = baseline.copy()
     b1.loc["2018-01-08":"2018-01-08 11", "temperature"] = np.nan
     b1 = m._add_categorical_features(b1)
-    b1 = m._daily_sufficiency(b1)
+    b1 = m._daily_fitting_sufficiency(b1)
     assert b1.loc["2018-01-08", "include_date"].sum() == 24
 
     b2 = baseline.copy()
     b2.loc["2018-01-08":"2018-01-08 12", "temperature"] = np.nan
     b2 = m._add_categorical_features(b2)
-    b2 = m._daily_sufficiency(b2)
+    b2 = m._daily_fitting_sufficiency(b2)
     assert b2.loc["2018-01-08", "include_date"].sum() == 0
     assert b2.loc["2018-01-09", "include_date"].sum() == 24
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [ ] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

CVRMSE would previously pass if the average observed was negative. This means it has behind-the-meter generation and CVRMSE is not valid. Additionally added PNRMSE as a passing criteria for the daily/billing models to allow behind-the-meter generation to pass.
