### PR TITLE
Fixes the warning data to only inculde invalid temperature rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Fix warning data on `high_frequency_temperature_data` warning.
 
 1.0.0
 -----

--- a/opendsm/eemeter/models/daily/data.py
+++ b/opendsm/eemeter/models/daily/data.py
@@ -402,7 +402,7 @@ class _DailyData:
                             ),
                             data=[
                                 timestamp.isoformat()
-                                for timestamp in invalid_temperature_rows.index
+                                for timestamp in invalid_temperature_rows[invalid_temperature_rows].index
                             ],
                         )
                     )


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

The warning data was returning all of the temperature rows rather than just the invalid ones. This should fix that. The two warnings have different signatures for data between whether the data is hourly or not, but I didn't want to change the signatures of anything in case people are relying on this format.

Also I didn't use blacken because when I ran it, a lot of files got reformatted.
