### PR TITLE
Ignores numpy warnings when dividing by zero and returns a NaN instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Squash numpy divide-by-zero warnings in caltrack hourly metrics.
 
 1.0.0
 -----

--- a/opendsm/eemeter/models/hourly_caltrack/metrics.py
+++ b/opendsm/eemeter/models/hourly_caltrack/metrics.py
@@ -327,9 +327,6 @@ class ModelMetrics(object):
         self.observed_kurtosis = combined["observed"].kurtosis()
         self.predicted_kurtosis = combined["predicted"].kurtosis()
 
-        self.observed_cvstd = combined["observed"].std() / self.observed_mean
-        self.predicted_cvstd = combined["predicted"].std() / self.predicted_mean
-
         self.r_squared = _compute_r_squared(combined)
         self.r_squared_adj = _compute_r_squared_adj(
             self.r_squared, self.merged_length, self.num_parameters
@@ -340,8 +337,12 @@ class ModelMetrics(object):
             combined, self.merged_length, self.num_parameters
         )
 
-        self.cvrmse = _compute_cvrmse(self.rmse, self.observed_mean)
-        self.cvrmse_adj = _compute_cvrmse_adj(self.rmse_adj, self.observed_mean)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            self.observed_cvstd = combined["observed"].std() / self.observed_mean
+            self.predicted_cvstd = combined["predicted"].std() / self.predicted_mean
+
+            self.cvrmse = _compute_cvrmse(self.rmse, self.observed_mean)
+            self.cvrmse_adj = _compute_cvrmse_adj(self.rmse_adj, self.observed_mean)
 
         # Create a new DataFrame with all rows removed where observed is
         # zero, so we can calculate a version of MAPE with the zeros excluded.


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [ ] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Moves dividable by zero computations under a numpy warning handler.
