### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ opendsm-1.1.0
 * Changed extreme values warning flag to check using IQR rule instead of median +- IQR which is incorrect
 * Fix warning data on `high_frequency_temperature_data` warning.
 * Squash numpy divide-by-zero warnings in caltrack Hourly metrics.
+* Migrate to modern Python logger interface to solve deprecation warnings.
 
 opendsm-1.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Development
 -----------
 
-* 
+* Migrate to modern Python logger interface to solve deprecation warnings.
 
 opendsm-1.1.0
 -----
@@ -22,7 +22,6 @@ opendsm-1.1.0
 * Changed extreme values warning flag to check using IQR rule instead of median +- IQR which is incorrect
 * Fix warning data on `high_frequency_temperature_data` warning.
 * Squash numpy divide-by-zero warnings in caltrack Hourly metrics.
-* Migrate to modern Python logger interface to solve deprecation warnings.
 
 opendsm-1.0.0
 -----

--- a/opendsm/common/clustering/bisect_k_means.py
+++ b/opendsm/common/clustering/bisect_k_means.py
@@ -140,7 +140,7 @@ class BisectingKMeans(_sklearn_BisectingKMeans):
             try:
                 cluster_to_bisect = self._bisecting_tree.get_cluster_to_bisect()
             except RecursionError:
-                logger.warn(
+                logger.warning(
                     f"encountered Recursion error during bisection for cluster size {i + 2}. Returning early"
                 )
                 return self
@@ -149,7 +149,7 @@ class BisectingKMeans(_sklearn_BisectingKMeans):
             try:
                 self._bisect(X, x_squared_norms, sample_weight, cluster_to_bisect)  # type: ignore
             except IndexError:
-                logger.warn(
+                logger.warning(
                     f"encountered IndexError during bisection for cluster size {i + 2}"
                 )
                 return self  # return early so that calculated labels can be returned until an error arose


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

**Description:**
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
