### PR TITLE
Bugfix/daily uncertainty and error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog
 Development
 -----------
 
+opendsm-1.2.2
+-----
+
+* Change daily model to use CVRMSE_adj and PNRMSE_adj as intended
+* Autocorrelation function is now consistent
+
 opendsm-1.2.1
 -----
 

--- a/opendsm/__version__.py
+++ b/opendsm/__version__.py
@@ -20,7 +20,7 @@
 __title__ = "opendsm"
 __description__ = "Measure demand-side program impacts"
 __url__ = "http://github.com/opendsm/opendsm"
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "opendsm"
 __author_email__ = "opendsm@lists.lfenergy.org"
 __license__ = "Apache 2.0"

--- a/opendsm/common/utils.py
+++ b/opendsm/common/utils.py
@@ -201,7 +201,7 @@ def unc_factor(n, interval="PI", alpha=0.10):
 MAD_k = 1 / norm_dist.ppf(0.75)
 
 
-def median_absolute_deviation(x, median=None):
+def median_absolute_deviation(x, median=None, axis=None):
     """
     This function calculates the Median Absolute Deviation (MAD) of a given array.
 
@@ -215,9 +215,9 @@ def median_absolute_deviation(x, median=None):
 
     mu = median
     if mu is None:
-        mu = np.median(x)
+        mu = np.median(x, axis=axis)
 
-    sigma = np.median(np.abs(x - mu)) * MAD_k
+    sigma = np.median(np.abs(x - mu), axis=axis) * MAD_k
 
     return sigma
 

--- a/opendsm/eemeter/models/daily/model.py
+++ b/opendsm/eemeter/models/daily/model.py
@@ -291,15 +291,15 @@ class DailyModel:
 
         # 3.5.1.1. If a day is missing a temperature value, the corresponding consumption value for that day should be masked.
         if mask_observed_with_missing_temperature:
-            dropped_rows[dropped_rows["temperature"].isna()]["observed"] = np.nan
+            dropped_rows.loc[dropped_rows["temperature"].isna(), "observed"] = np.nan
 
         df_eval = pd.concat([df_eval, dropped_rows])
 
         return df_eval.sort_index()
 
     def _check_model_fit(self):
-        cvrmse = self.baseline_metrics.cvrmse
-        pnrmse = self.baseline_metrics.pnrmse
+        cvrmse = self.baseline_metrics.cvrmse_adj
+        pnrmse = self.baseline_metrics.pnrmse_adj
 
         cvrmse_threshold = self.settings.cvrmse_threshold
         pnrmse_threshold = self.settings.pnrmse_threshold
@@ -392,6 +392,9 @@ class DailyModel:
             # Make all keys in metrics_dict lowercase
             # will contain ['wRMSE', 'RMSE', 'MAE', 'CVRMSE', 'PNRMSE']
             metrics_dict_lower = {k.lower(): v for k, v in info.get("error").items()}
+            # do not have adjusted metrics in prior versions, so we use unadjusted metrics
+            metrics_dict_lower["cvrmse_adj"] = metrics_dict_lower["cvrmse"]
+            metrics_dict_lower["pnrmse_adj"] = metrics_dict_lower["pnrmse"]
             daily_model.baseline_metrics = BaselineMetricsFromDict(metrics_dict_lower)
 
         daily_model.is_fitted = True

--- a/opendsm/eemeter/models/daily/model.py
+++ b/opendsm/eemeter/models/daily/model.py
@@ -291,7 +291,7 @@ class DailyModel:
 
         # 3.5.1.1. If a day is missing a temperature value, the corresponding consumption value for that day should be masked.
         if mask_observed_with_missing_temperature:
-            dropped_rows.loc[dropped_rows["temperature"].isna(), "observed"] = np.nan
+            dropped_rows[dropped_rows["temperature"].isna()]["observed"] = np.nan
 
         df_eval = pd.concat([df_eval, dropped_rows])
 

--- a/tests/common/metrics.py
+++ b/tests/common/metrics.py
@@ -33,7 +33,7 @@ def test_acf():
     # Test case 3: Test with a moving mean and standard deviation
     x = np.array([1, 2, 3, 4, 5])
     expected_output = np.array([1.0, 1.0, 1.0, 1.0])
-    assert np.allclose(acf(x, moving_mean_std=True), expected_output)
+    assert np.allclose(acf(x, ac_type="moving_stats"), expected_output)
 
     # Test case 4: Test with a specific lag_n
     x = np.array([1, 2, 3, 4, 5])


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

This fixes the daily model to use CVRMSE_adj and PNRMSE_adj and consistent autocorrelation function usage.
