### PR TITLE
Bugfix/seeded clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog
 Development
 -----------
 
+opendsm-1.2.3
+-----
+
+* Spectral clustering is now seeded appropriately
+* Fixed bug making seed in main hourly settings not be passed to clustering settings
+
 opendsm-1.2.2
 -----
 

--- a/opendsm/common/clustering/cluster.py
+++ b/opendsm/common/clustering/cluster.py
@@ -264,6 +264,9 @@ def _spectral_clustering(
     min_cluster_size = settings.spectral.scoring.min_cluster_size
     max_non_outlier_cluster_count = 200
 
+    np_state = np.random.get_state()
+    np.random.seed(settings._seed)
+
     # transform data as spectral clustering doesn't like negative values
     # data = np.exp(-data / np.std(data))
 
@@ -284,6 +287,7 @@ def _spectral_clustering(
             gamma=settings.spectral.gamma,
             eigen_tol=settings.spectral.eigen_tol,
             assign_labels=settings.spectral.assign_labels,
+            random_state=settings._seed
         )
 
         # hide UserWarning from sklearn
@@ -291,7 +295,8 @@ def _spectral_clustering(
             warnings.filterwarnings("ignore", category=UserWarning)
             labels = algo.fit_predict(X)
 
-        X = algo.affinity_matrix_
+        if n_clusters == n_cluster_lower:
+            X = algo.affinity_matrix_
 
         # Calculate a score for the clustering
         score, score_unable_to_be_calculated = _scoring.score_clusters(
@@ -321,6 +326,8 @@ def _spectral_clustering(
 
         if HoF is None or result.score < HoF.score:
             HoF = result
+
+    np.random.set_state(np_state)
 
     return HoF.labels
 

--- a/opendsm/common/clustering/settings.py
+++ b/opendsm/common/clustering/settings.py
@@ -507,14 +507,16 @@ class ClusteringSettings(BaseSettings):
         ge=0,
     )
 
+    _seed: Optional[int] = pydantic.PrivateAttr(
+        default=None
+    )
+
     @pydantic.model_validator(mode="after")
     def _check_seed(self):
-        if self.seed is None:
+        if self.seed is None and self._seed is None:
             self._seed = np.random.randint(0, 2**32 - 1, dtype=np.int64)
         else:
             self._seed = self.seed
-
-        self._seed = self._seed
 
         return self
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Spectral clustering is now seeded. In its current configuration it should be deterministic, but it is not for unknown reasons. Clustering _seed was not being inherited from the main hourly settings class. This has also been fixed
