### PR TITLE
fixed bug in ci_rating and added autocorr normalized metrics

### DIFF
--- a/opendsm/common/metrics.py
+++ b/opendsm/common/metrics.py
@@ -328,6 +328,10 @@ class BaselineMetrics(ArbitraryPydanticModel):
         return safe_divide(self.rmse, self.observed.mean, self._min_denominator)
 
     @computed_field_cached_property()
+    def cvrmse_autocorr(self) -> float:
+        return safe_divide(self.rmse_autocorr, self.observed.mean, self._min_denominator)
+
+    @computed_field_cached_property()
     def cvrmse_adj(self) -> float:
         return safe_divide(self.rmse_adj, self.observed.mean, self._min_denominator)
 
@@ -340,6 +344,10 @@ class BaselineMetrics(ArbitraryPydanticModel):
     @computed_field_cached_property()
     def pnrmse(self) -> float:
         return safe_divide(self.rmse, self.observed.iqr, self._min_denominator)
+
+    @computed_field_cached_property()
+    def pnrmse_autocorr(self) -> float:
+        return safe_divide(self.rmse_autocorr, self.observed.iqr, self._min_denominator)
 
     @computed_field_cached_property()
     def pnrmse_adj(self) -> float:
@@ -482,17 +490,17 @@ class BaselineMetrics(ArbitraryPydanticModel):
     @computed_field_cached_property()
     def ci_rating(self) -> str:
         ci = self.ci
-        if ci > 0.85:
+        if ci >= 0.85:
             return "excellent"
-        elif 0.76 <= ci <= 0.85:
+        elif 0.75 <= ci < 0.85:
             return "very good"
-        elif 0.66 <= ci <= 0.75:
+        elif 0.65 <= ci < 0.75:
             return "good"
-        elif 0.61 <= ci <= 0.65:
+        elif 0.60 <= ci < 0.65:
             return "satisfactory"
-        elif 0.51 <= ci <= 0.60:
+        elif 0.50 <= ci < 0.60:
             return "poor"
-        elif 0.41 <= ci <= 0.50:
+        elif 0.40 <= ci < 0.50:
             return "bad"
         else:
             return "very bad"

--- a/opendsm/common/metrics.py
+++ b/opendsm/common/metrics.py
@@ -316,6 +316,10 @@ class BaselineMetrics(ArbitraryPydanticModel):
         return self.mse**0.5
 
     @computed_field_cached_property()
+    def rmse_autocorr(self) -> float:
+        return (self.sse / self.n_prime) ** 0.5
+
+    @computed_field_cached_property()
     def rmse_adj(self) -> float:
         return (self.sse / self.ddof) ** 0.5
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure tests pass and coverage has not fallen `docker-compose run --rm test`.
- [x] Update the [CHANGELOG.md](../CHANGELOG.md) to describe your changes in a bulleted list under the "Development" section at the top of the changelog. If this section does not exist, create it.
- [x] Make sure code style follows PEP 008 using `docker-compose run --rm blacken`.
- [x] Make sure that new functions and classes have inline docstrings valid docstrings and any public classes and methods are included members in the docs/reference files. Please use [google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
  Sphinx docs can be built with the following command: `docker-compose run --rm --entrypoint="make -C docs html" shell`. Please note and fix any warnings.
- [x] Make sure that all git commits are have the "Signed-off-by" message for
  the Developer Certificate of Origin. When you're making a commit, just add
  the `-s/--signoff` flag (e.g., `git commit -s`).

### Description

Fixes bug in ci_rating and adds autocorrelated adjusted, normalized error metrics
